### PR TITLE
Ensure calendar payload includes meeting title

### DIFF
--- a/src/Booking/FluentBookingConnector.php
+++ b/src/Booking/FluentBookingConnector.php
@@ -324,6 +324,22 @@ class FluentBookingConnector
             $body['detail'] = $desc;
         }
 
+        $calendarEntry = isset($body['calendar_entry']) && is_array($body['calendar_entry'])
+            ? $body['calendar_entry']
+            : [];
+        if ($title !== '') {
+            $calendarEntry['title'] = $title;
+        }
+        if ($desc !== '') {
+            $calendarEntry['description'] = $desc;
+        }
+        if ($addrLine !== '') {
+            $calendarEntry['location'] = $addrLine;
+        }
+        if ($calendarEntry) {
+            $body['calendar_entry'] = $calendarEntry;
+        }
+
         $teamConfig = $this->teamConfig($payload['team'] ?? '');
         $calendarId = 0;
         if (isset($payload['meta']['calendar_id'])) {


### PR DESCRIPTION
## Summary
- add calendar_entry payload data when creating FluentBooking schedules so the computed title, description, and location reach the calendar entry

## Testing
- php -l src/Booking/FluentBookingConnector.php

------
https://chatgpt.com/codex/tasks/task_e_68d09902d88c83229ef4907e95808e11