### PR TITLE
Add configurable Einbau niche popup for product categories

### DIFF
--- a/sg-montage.css
+++ b/sg-montage.css
@@ -54,6 +54,99 @@
 .sg-note.warn{ color:#c00; }
 .sg-msg.warn { color: #c00; font-weight: 600; }
 
+.sg-niche-popup-wrap { margin: 18px 0; }
+.sg-niche-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: #0b0b0b;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s ease, transform .2s ease;
+}
+.sg-niche-btn:hover,
+.sg-niche-btn:focus {
+  background: #2a2a2a;
+}
+.sg-niche-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0.15);
+}
+
+.sg-niche-popup {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.sg-niche-popup[hidden] { display: none; }
+.sg-niche-popup__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+.sg-niche-popup__content {
+  position: relative;
+  background: #fff;
+  border-radius: 18px;
+  padding: 28px;
+  width: min(720px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.25);
+}
+.sg-niche-popup__close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  color: #000;
+  font-size: 1.8rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.sg-niche-popup__close:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0,0,0,0.2);
+}
+.sg-niche-popup__video {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  height: 0;
+  margin-bottom: 18px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+}
+.sg-niche-popup__video iframe,
+.sg-niche-popup__video video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.sg-niche-popup__text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+.sg-niche-popup__text p { margin-bottom: 1em; }
+.sg-niche-popup__text:last-child p:last-child { margin-bottom: 0; }
+.sg-niche-popup__video-link { font-weight: 600; }
+
+body.sg-niche-popup-open { overflow: hidden; }
+
 .sg-booking-auto-tabs-nav {
   display: flex;
   gap: 10px;
@@ -122,6 +215,7 @@
 @media (max-width:640px){
   .sg-montage-card{ padding:14px; }
   .sg-service-select{ min-width:100%; }
+  .sg-niche-popup__content{ padding:22px 18px; }
 }
 
 /* Tooltip */

--- a/sg-montage.js
+++ b/sg-montage.js
@@ -64,6 +64,61 @@
     });
   });
 
+  /* ---------- Produktseite: Nischen-Popup ---------- */
+  function closeNichePopup($popup, returnFocus=true){
+    if(!$popup || !$popup.length) return;
+    $popup.attr('aria-hidden','true').attr('hidden',true).removeClass('is-open');
+    const $trigger=$popup.data('trigger');
+    if($trigger && $trigger.length){
+      $trigger.attr('aria-expanded','false');
+      if(returnFocus) $trigger.trigger('focus');
+    }
+    $popup.removeData('trigger');
+    if($('.sg-niche-popup.is-open').length===0){
+      $('body').removeClass('sg-niche-popup-open');
+    }
+  }
+
+  function openNichePopup($button, $popup){
+    if(!$popup || !$popup.length) return;
+    $('.sg-niche-popup.is-open').each(function(){ closeNichePopup($(this), false); });
+    $popup.removeAttr('hidden').attr('aria-hidden','false').addClass('is-open');
+    $popup.data('trigger',$button);
+    if($button && $button.length){
+      $button.attr('aria-expanded','true');
+    }
+    $('body').addClass('sg-niche-popup-open');
+    const $focus=$popup.find('.sg-niche-popup__close').first();
+    if($focus.length){ setTimeout(function(){ $focus.trigger('focus'); }, 20); }
+  }
+
+  $(document).on('click','.sg-niche-btn',function(e){
+    e.preventDefault();
+    const $btn=$(this);
+    const id=$btn.data('target');
+    if(!id) return;
+    const $popup=$('#'+id);
+    if(!$popup.length) return;
+    if($popup.hasClass('is-open')) closeNichePopup($popup);
+    else openNichePopup($btn,$popup);
+  });
+
+  $(document).on('click','.sg-niche-popup__close, .sg-niche-popup__overlay',function(e){
+    e.preventDefault();
+    const $popup=$(this).closest('.sg-niche-popup');
+    closeNichePopup($popup);
+  });
+
+  $(document).on('keydown',function(e){
+    if(e.key==='Escape' || e.keyCode===27){
+      const $open=$('.sg-niche-popup.is-open').last();
+      if($open.length){
+        e.preventDefault();
+        closeNichePopup($open);
+      }
+    }
+  });
+
   /* ---------- PLZ Sync ---------- */
   function pushPlz(plz){
     // cache in cookie as fallback for session propagation


### PR DESCRIPTION
## Summary
- add product category metadata fields for configuring Einbau niche videos and notes
- expose a new `[sg_niche_popup]` shortcode that renders a modal button for Einbau products with matching category content
- style and script the modal popup for accessible open/close behaviour on Breakdance product templates

## Testing
- php -l sg-montagerechner.php

------
https://chatgpt.com/codex/tasks/task_e_68d09e8abdfc8322bd44a52c1a340958